### PR TITLE
fix: add try-catch for navigator.vibrate call

### DIFF
--- a/src/components/Habit/HabitHeader.jsx
+++ b/src/components/Habit/HabitHeader.jsx
@@ -46,7 +46,11 @@ function HabitHeader(props) {
 			200
 		);
 
-		navigator?.vibrate(isCompleted ? [10, 10, 10, 10, 10] : 10);
+		try {
+			navigator?.vibrate(isCompleted ? [10, 10, 10, 10, 10] : 10);
+		} catch (e) {
+			console.error(e);
+		}
 
 		habitsDispatch({
 			type: 'updateProgress',


### PR DESCRIPTION
workaround for issue where user can't mark current day as complete in firefox, resolves https://github.com/iNikAnn/DoHabit/issues/17