### PR TITLE
refactor: replace switch div with native checkbox

### DIFF
--- a/src/shared/ui/switch/Switch.module.css
+++ b/src/shared/ui/switch/Switch.module.css
@@ -5,7 +5,7 @@
 
 .switch {
 	/* outline: 1px solid tomato; */
-	display: inline-block;
+	display: flex;
 	cursor: pointer;
 	position: relative;
 	width: calc(var(--indicator-width) * 3);
@@ -22,14 +22,9 @@
 
 .input {
 	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border-width: 0;
+	left: 0;
+	appearance: none;
+	opacity: 0;
 }
 
 .indicator {

--- a/src/shared/ui/switch/Switch.module.css
+++ b/src/shared/ui/switch/Switch.module.css
@@ -5,12 +5,31 @@
 
 .switch {
 	/* outline: 1px solid tomato; */
+	display: inline-block;
+	cursor: pointer;
 	position: relative;
 	width: calc(var(--indicator-width) * 3);
 	height: calc(var(--indicator-width) + var(--switch-padding) * 2);
 	background-color: var(--bg-color-primary);
 	border: 2px solid var(--bg-color-tertiary);
 	border-radius: 40px;
+}
+
+.switch:has(.input:focus-visible) {
+	outline: 2px solid dodgerblue;
+	outline-offset: 2px;
+}
+
+.input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
 }
 
 .indicator {

--- a/src/shared/ui/switch/Switch.tsx
+++ b/src/shared/ui/switch/Switch.tsx
@@ -11,16 +11,19 @@ interface Props {
  */
 function Switch({ isActive, onClick }: Props) {
 	return (
-		<div
-			role='button'
-			className={styles.switch}
-			onClick={onClick}
-		>
+		<label className={styles.switch}>
+			<input
+				type='checkbox'
+				className={styles.input}
+				checked={isActive}
+				onChange={onClick}
+				{...{ switch: '' } as any}
+			/>
 			<div className={clsx(
 				styles.indicator,
 				isActive && styles.active
 			)} />
-		</div>
+		</label>
 	);
 }
 


### PR DESCRIPTION
## Summary

Refactored the `Switch` component to use a native checkbox input instead of a clickable `div`, improving accessibility and keyboard navigation while preserving the existing visual appearance and public API.

## Changes

* Replaced the non-semantic clickable `div` with a native `<input type="checkbox">`
* Wrapped the input in a semantic `<label>`
* Kept the existing `isActive` and `onClick` props unchanged
* Added a visually hidden checkbox input that remains accessible to screen readers and keyboard users
* Preserved the current switch styling and toggle animation

## Testing

* Verified mouse click toggles the switch correctly
* Verified keyboard navigation reaches the switch using `Tab`
* Verified the switch can be toggled using the `Space` key
* Confirmed the visual appearance remains unchanged

Fixes #29
