### PR TITLE
feat: bulk note selection by month label in NoteList

### DIFF
--- a/src/entities/note/model/store.ts
+++ b/src/entities/note/model/store.ts
@@ -89,6 +89,26 @@ export const useNotesStore = create<NoteState>()(
 				return { selectedIds: nextSelected, isSelectionMode };
 			}),
 
+			toggleSelectMany: (ids) => set((s) => {
+				const nextSelected = new Set(s.selectedIds);
+
+				// Select the whole group unless every note in it
+				// is already selected — then deselect the group
+				const allSelected = ids.length > 0 && ids.every((id) => nextSelected.has(id));
+
+				for (const id of ids) {
+					if (allSelected) {
+						nextSelected.delete(id);
+					} else {
+						nextSelected.add(id);
+					}
+				}
+
+				const isSelectionMode = nextSelected.size > 0;
+
+				return { selectedIds: nextSelected, isSelectionMode };
+			}),
+
 			notesDispatch: (action) => set(
 				(s) => ({ notes: notesReducer(s.notes, action) })
 			),

--- a/src/entities/note/model/types.ts
+++ b/src/entities/note/model/types.ts
@@ -58,6 +58,7 @@ export interface NoteState {
 	enterSelectionMode: (initialId?: string) => void;
 	exitSelectionMode: () => void;
 	toggleSelect: (id: string) => void;
+	toggleSelectMany: (ids: string[]) => void;
 
 	notesDispatch: (action: NoteAction) => void;
 

--- a/src/widgets/note-list/ui/NoteList.module.css
+++ b/src/widgets/note-list/ui/NoteList.module.css
@@ -38,3 +38,18 @@
 	border-radius: var(--border-radius-tertiary);
 	box-shadow: 0 0 10px color-mix(in srgb, var(--bg) 50%, transparent);
 }
+
+/* in selection mode the label toggles selection of its month group */
+.monthLabelSelectable {
+	pointer-events: auto;
+	cursor: pointer;
+	transition: filter 0.15s ease;
+}
+
+.monthLabelSelectable:hover {
+	filter: brightness(1.2);
+}
+
+.monthLabelSelectable:active {
+	filter: brightness(0.9);
+}

--- a/src/widgets/note-list/ui/NoteList.tsx
+++ b/src/widgets/note-list/ui/NoteList.tsx
@@ -1,4 +1,5 @@
 import styles from './NoteList.module.css';
+import clsx from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { groupBy, startCase } from 'es-toolkit';
@@ -50,6 +51,7 @@ function NoteList(props: NoteListProps) {
 	// Management actions to trigger or modify bulk selection state
 	const enterSelectionMode = useNotesStore((s) => s.enterSelectionMode);
 	const toggleSelect = useNotesStore((s) => s.toggleSelect);
+	const toggleSelectMany = useNotesStore((s) => s.toggleSelectMany);
 
 	// Actions and menu controls
 	const openNoteForm = useNoteFormStore((s) => s.openEdit);
@@ -187,11 +189,27 @@ function NoteList(props: NoteListProps) {
 									<AnimatePresence mode='popLayout' propagate>
 										<motion.small
 											key={groupKey}
-											className={styles.monthLabel}
+											className={clsx(
+												styles.monthLabel,
+												isSelectionMode && styles.monthLabelSelectable
+											)}
 											variants={monthLabelVariants}
 											initial='initial'
 											animate='animate'
 											exit='exit'
+											// In selection mode the label toggles selection
+											// of all notes in this month group only
+											role={isSelectionMode ? 'button' : undefined}
+											tabIndex={isSelectionMode ? 0 : undefined}
+											onClick={() => {
+												if (isSelectionMode) toggleSelectMany(notes.map((n) => n.id));
+											}}
+											onKeyDown={(e) => {
+												if (isSelectionMode && (e.key === 'Enter' || e.key === ' ')) {
+													e.preventDefault();
+													toggleSelectMany(notes.map((n) => n.id));
+												}
+											}}
 										>
 											{startCase(monthLabels[monthIndex])}
 										</motion.small>


### PR DESCRIPTION
## Summary

Closes #35

In selection mode, clicking a month label now toggles selection of every note in that month group, exactly per the expected behavior in the issue:

- none/some notes in the group selected → the label click **selects all** notes in the group
- all notes in the group selected → the label click **deselects** the group

## Implementation

- New `toggleSelectMany(ids)` action in the notes store, mirroring the existing `toggleSelect` semantics (`isSelectionMode` recomputed from the resulting selection size).
- `NoteList` passes the ids of the group being rendered, so selection is **strictly limited to the current group context**: the group array derives from `scopeNotes → yearNotes → taggedNotes → visibleNotes`, which already encodes the habit-vs-general note type, the year filter, and the active tag. Same-named months from other years live in different `YYYY-MM` groups and are never touched — covering both potential issues called out in the issue.
- In selection mode the label gets `cursor: pointer` + hover/active feedback. `pointer-events` is re-enabled on the label element only, so the sticky wrapper row stays click-through as before. Also added `role="button"`, `tabIndex`, and Enter/Space handling since the label becomes interactive.
- Outside selection mode nothing changes (no cursor, no handler effect).

## Verified

Ran the app and tested in-browser against seeded notes across 3 months:
- label click selects both notes of that month only; other months' selections untouched
- second click deselects the group
- with a partial selection in the group, label click selects the remaining notes
- no console errors

`npm run type-check`, `eslint src`, stylelint on the changed CSS, and `vitest run` (19/19) all pass.