### PR TITLE
test: add clearLocalStorage unit tests

### DIFF
--- a/src/shared/lib/local-storage/clear-local-storage/clearLocalStorage.test.ts
+++ b/src/shared/lib/local-storage/clear-local-storage/clearLocalStorage.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearLocalStorage } from './clearLocalStorage';
+
+describe('clearLocalStorage', () => {
+    const removeItem = vi.fn();
+    const clear = vi.fn();
+
+    beforeEach(() => {
+        vi.stubGlobal('localStorage', {
+            removeItem,
+            clear,
+        });
+
+        removeItem.mockClear();
+        clear.mockClear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('should remove a single key', () => {
+        clearLocalStorage('user');
+
+        expect(removeItem).toHaveBeenCalledWith('user');
+    });
+
+    test('should remove multiple keys', () => {
+        clearLocalStorage(['user', 'settings']);
+
+        expect(removeItem).toHaveBeenCalledTimes(2);
+        expect(removeItem).toHaveBeenCalledWith('user');
+        expect(removeItem).toHaveBeenCalledWith('settings');
+    });
+
+    test('should clear all local storage when no keys are provided', () => {
+        clearLocalStorage();
+
+        expect(clear).toHaveBeenCalledOnce();
+    });
+});

--- a/src/shared/lib/local-storage/clear-local-storage/clearLocalStorage.test.ts
+++ b/src/shared/lib/local-storage/clear-local-storage/clearLocalStorage.test.ts
@@ -8,11 +8,10 @@ describe('clearLocalStorage', () => {
     beforeEach(() => {
         vi.stubGlobal('localStorage', {
             removeItem,
-            clear,
+            clear
         });
 
-        removeItem.mockClear();
-        clear.mockClear();
+        vi.clearAllMocks();
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary

- Added unit tests for `clearLocalStorage`.
- Covered removing a single key.
- Covered removing multiple keys.
- Covered clearing all local storage when no keys are provided.

## Test

- All 52 tests pass successfully.

Related to #41