### PR TITLE
test: add router helper unit tests

### DIFF
--- a/src/shared/lib/router/helpers.test.ts
+++ b/src/shared/lib/router/helpers.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getInitialRouteState, getModalPath, getNavigationTarget } from './helpers';
+
+describe('router helpers', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe('getInitialRouteState', () => {
+        test('should return undefined when history state is empty', () => {
+            vi.stubGlobal('window', {
+                history: { state: null }
+            });
+
+            expect(getInitialRouteState()).toBeUndefined();
+        });
+
+        test('should return state from router usr wrapper', () => {
+            const state = {
+                modalTitle: 'Diary',
+                habitId: 'habit-1'
+            };
+
+            vi.stubGlobal('window', {
+                history: { state: { usr: state } }
+            });
+
+            expect(getInitialRouteState<'DIARY'>()).toEqual(state);
+        });
+
+        test('should fall back to native history state', () => {
+            const state = {
+                modalTitle: 'Menu'
+            };
+
+            vi.stubGlobal('window', {
+                history: { state }
+            });
+
+            expect(getInitialRouteState<'MENU'>()).toEqual(state);
+        });
+    });
+
+    describe('getModalPath', () => {
+        test('should return the correct modal path', () => {
+            expect(getModalPath('MENU')).toBe('/modal/menu');
+            expect(getModalPath('STATISTICS')).toBe('/modal/habit-statistics');
+        });
+    });
+
+    describe('getNavigationTarget', () => {
+        test('should return navigation path and state', () => {
+            const state = {
+                modalTitle: 'Diary',
+                habitId: 'habit-1'
+            };
+
+            expect(getNavigationTarget('DIARY', state)).toEqual({
+                to: '/modal/diary',
+                state
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Added unit tests for router helper functions.
- Covered `getInitialRouteState`.
- Covered `getModalPath`.
- Covered `getNavigationTarget`.

## Test

- All 54 tests pass successfully.

Related to #41