### PR TITLE
test: add extractUniqueTags unit tests

### DIFF
--- a/src/shared/lib/text/extract-unique-tags/extractUniqueTags.test.ts
+++ b/src/shared/lib/text/extract-unique-tags/extractUniqueTags.test.ts
@@ -3,51 +3,55 @@ import { extractUniqueTags } from './extractUniqueTags';
 
 describe('extractUniqueTags', () => {
 	test('extracts hashtags from a string', () => {
-		expect(extractUniqueTags('Build habits with #focus and #consistency')).toEqual([
-			'#focus',
-			'#consistency'
-		]);
+		const input = 'Build habits with #focus and #consistency';
+
+		expect(extractUniqueTags(input)).toEqual(['#focus', '#consistency']);
 	});
 
 	test('normalizes hashtags to lowercase and removes duplicates', () => {
-		expect(extractUniqueTags('#Focus #focus #FOCUS #Health')).toEqual([
-			'#focus',
-			'#health'
-		]);
+		const input = '#Focus #focus #FOCUS #Health';
+
+		expect(extractUniqueTags(input)).toEqual(['#focus', '#health']);
 	});
 
 	test('extracts hashtags from an array of strings', () => {
-		expect(extractUniqueTags([
-			'Morning #exercise',
-			'Evening #reading',
-			'More #exercise'
-		])).toEqual(['#exercise', '#reading']);
+		const input = ['Morning #exercise', 'Evening #reading', 'More #exercise'];
+
+		expect(extractUniqueTags(input)).toEqual(['#exercise', '#reading']);
 	});
 
 	test('extracts hashtags from objects containing text', () => {
-		expect(extractUniqueTags([
+		const input = [
 			{ text: 'Work on #typescript' },
 			{ text: 'Learn #react and #typescript' }
-		])).toEqual(['#typescript', '#react']);
+		];
+
+		expect(extractUniqueTags(input)).toEqual(['#typescript', '#react']);
 	});
 
 	test('returns an empty array when no hashtags exist', () => {
 		expect(extractUniqueTags('There are no tags here')).toEqual([]);
 	});
 
-	test('sorts hashtags in ascending order', () => {
-		expect(extractUniqueTags('#zebra #apple #banana', { order: 'asc' })).toEqual([
-			'#apple',
-			'#banana',
-			'#zebra'
-		]);
+	test('returns an empty array for empty inputs', () => {
+		expect(extractUniqueTags([])).toEqual([]);
 	});
 
-	test('sorts hashtags in descending order', () => {
-		expect(extractUniqueTags('#apple #zebra #banana', { order: 'desc' })).toEqual([
-			'#zebra',
-			'#banana',
-			'#apple'
-		]);
+	test('sorts hashtags in asc and desc order', () => {
+		const input = '#zebra #apple #banana';
+
+		expect(extractUniqueTags(input, { order: 'asc' })).toEqual(['#apple', '#banana', '#zebra']);
+		expect(extractUniqueTags(input, { order: 'desc' })).toEqual(['#zebra', '#banana', '#apple']);
+	});
+
+	test('handles objects with missing or invalid text property', () => {
+		const input = [
+			{ text: 'Valid #tag' },
+			{ wrongField: '#ignored' },
+			null
+		];
+
+		// @ts-expect-error testing invalid structure
+		expect(extractUniqueTags(input)).toEqual(['#tag']);
 	});
 });

--- a/src/shared/lib/text/extract-unique-tags/extractUniqueTags.test.ts
+++ b/src/shared/lib/text/extract-unique-tags/extractUniqueTags.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+import { extractUniqueTags } from './extractUniqueTags';
+
+describe('extractUniqueTags', () => {
+	test('extracts hashtags from a string', () => {
+		expect(extractUniqueTags('Build habits with #focus and #consistency')).toEqual([
+			'#focus',
+			'#consistency'
+		]);
+	});
+
+	test('normalizes hashtags to lowercase and removes duplicates', () => {
+		expect(extractUniqueTags('#Focus #focus #FOCUS #Health')).toEqual([
+			'#focus',
+			'#health'
+		]);
+	});
+
+	test('extracts hashtags from an array of strings', () => {
+		expect(extractUniqueTags([
+			'Morning #exercise',
+			'Evening #reading',
+			'More #exercise'
+		])).toEqual(['#exercise', '#reading']);
+	});
+
+	test('extracts hashtags from objects containing text', () => {
+		expect(extractUniqueTags([
+			{ text: 'Work on #typescript' },
+			{ text: 'Learn #react and #typescript' }
+		])).toEqual(['#typescript', '#react']);
+	});
+
+	test('returns an empty array when no hashtags exist', () => {
+		expect(extractUniqueTags('There are no tags here')).toEqual([]);
+	});
+
+	test('sorts hashtags in ascending order', () => {
+		expect(extractUniqueTags('#zebra #apple #banana', { order: 'asc' })).toEqual([
+			'#apple',
+			'#banana',
+			'#zebra'
+		]);
+	});
+
+	test('sorts hashtags in descending order', () => {
+		expect(extractUniqueTags('#apple #zebra #banana', { order: 'desc' })).toEqual([
+			'#zebra',
+			'#banana',
+			'#apple'
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Add unit test coverage for `extractUniqueTags`.

### Covered behavior

* extracts hashtags from strings
* supports arrays of strings and text objects
* normalizes tags to lowercase
* removes duplicate hashtags
* handles text without hashtags
* supports ascending and descending sorting

### Validation

* added focused Vitest coverage for `extractUniqueTags`

Related to #41
